### PR TITLE
deb pkg build

### DIFF
--- a/CMakeLists.ubuntu.txt
+++ b/CMakeLists.ubuntu.txt
@@ -12,3 +12,8 @@ add_executable(zpool_prometheus
         zpool_prometheus.c)
 target_link_libraries(zpool_prometheus zfs nvpair)
 install(TARGETS zpool_prometheus DESTINATION ${INSTALL_DIR}/bin)
+
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS "ON")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "RE")
+INCLUDE(CPack)


### PR DESCRIPTION
Added CPACK directives to ubuntu CMakeLists.txt for easy package building. I believe it will take CMAKE_PROJECT_VERSION and CMAKE_PROJECT_DESCRIPTION if set for a more explanatory package build if you like.