### PR TITLE
Add -D_LARGEFILE64_SOURCE to CMAKE_C_FLAGS for Ubuntu builds

### DIFF
--- a/CMakeLists.ubuntu.txt
+++ b/CMakeLists.ubuntu.txt
@@ -5,6 +5,7 @@ project(zpool_prometheus C)
 # be sure to (apt) install the header files package, libzfslinux-dev
 set(INSTALL_DIR /usr)
 set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_LARGEFILE64_SOURCE")
 
 include_directories(${INSTALL_DIR}/include/libspl ${INSTALL_DIR}/include/libzfs)
 link_directories(${INSTALL_DIR}/lib)


### PR DESCRIPTION
Building fails using the `CMakeLists.ubuntu.txt` on recent versions of Ubuntu (21.04 in my case). 

It fails with the following error:
```
-----8<-----
[ 50%] Building C object CMakeFiles/zpool_prometheus.dir/zpool_prometheus.c.o                                
In file included from /usr/include/libspl/sys/mnttab.h:35,                                                   
                 from /usr/include/libzfs/libzfs.h:38,                                                       
                 from /zpool_prometheus/zpool_prometheus.c:46:                                               
/usr/include/libspl/sys/stat.h:37:28: warning: 'struct stat64' declared inside parameter list will not be visible outside of this definition or declaration                                                          
   37 | fstat64_blk(int fd, struct stat64 *st)                                                            
      |                            ^~~~~~                                                                 
/usr/include/libspl/sys/stat.h: In function 'fstat64_blk':                                                
/usr/include/libspl/sys/stat.h:39:6: warning: implicit declaration of function 'fstat64'; did you mean 'fstatat'? [-Wimplicit-function-declaration]                                                                  
   39 |  if (fstat64(fd, st) == -1)                  
      |      ^~~~~~~                                 
      |      fstatat                                 
In file included from /usr/include/libspl/sys/stat.h:29,                                                  
                 from /usr/include/libspl/sys/mnttab.h:35,                                                
                 from /usr/include/libzfs/libzfs.h:38,                                                    
                 from /zpool_prometheus/zpool_prometheus.c:46:                                            
/usr/include/libspl/sys/stat.h:43:16: error: invalid use of undefined type 'struct stat64'                                                                                                                           
   43 |  if (S_ISBLK(st->st_mode)) {                 
      |                ^~                            
In file included from /usr/include/libspl/sys/mnttab.h:35,                                                
                 from /usr/include/libzfs/libzfs.h:38,                                                    
                 from /zpool_prometheus/zpool_prometheus.c:46:                                            
/usr/include/libspl/sys/stat.h:44:34: error: invalid use of undefined type 'struct stat64'                                                                                                                           
   44 |   if (ioctl(fd, BLKGETSIZE64, &st->st_size) != 0)                                                 
      |                                  ^~                                                               
In file included from /usr/include/libzfs/libzfs.h:38,                                                    
                 from /zpool_prometheus/zpool_prometheus.c:46:                                            
/usr/include/libspl/sys/mnttab.h: At top level:                                                           
/usr/include/libspl/sys/mnttab.h:76:12: warning: 'struct stat64' declared inside parameter list will not be visible outside of this definition or declaration                                                        
   76 |     struct stat64 *statbuf);                 
      |            ^~~~~~                            
make[2]: *** [CMakeFiles/zpool_prometheus.dir/build.make:82: CMakeFiles/zpool_prometheus.dir/zpool_prometheus.c.o] Error 1                                                                                           
make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/zpool_prometheus.dir/all] Error 2                                                                                                                                  
make: *** [Makefile:171: all] Error 2
``` 

It built on the latest LTS release (i.e. 20.04). The `CMakeLists.txt` works on both.
It looks like the difference was the missing `-D_LARGEFILE64_SOURCE` flag.