### PR TITLE
Make CMakeLists files more similar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(zpool_prometheus C)
 #     -D ZFS_INSTALL_BASE=/usr
 # on the cmake command-line.
 set(ZFS_INSTALL_BASE /usr/local CACHE STRING "zfs installation base directory")
+set(CMAKE_INSTALL_PREFIX /usr/local)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_LARGEFILE64_SOURCE")
 
@@ -15,4 +16,4 @@ link_directories(${ZFS_INSTALL_BASE}/lib)
 add_executable(zpool_prometheus
         zpool_prometheus.c)
 target_link_libraries(zpool_prometheus zfs nvpair)
-install(TARGETS zpool_prometheus DESTINATION ${ZFS_INSTALL_BASE}/bin)
+install(TARGETS zpool_prometheus DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/CMakeLists.ubuntu.txt
+++ b/CMakeLists.ubuntu.txt
@@ -2,16 +2,17 @@ cmake_minimum_required(VERSION 3.7)
 project(zpool_prometheus C)
 
 # by default Ubuntu installs the header files and libraries in /usr
-# be sure to (apt) install the header files package, libzfslinux-dev
-set(INSTALL_DIR /usr)
+# be sure to (apt) install the header files package: libzfslinux-dev
+set(ZFS_INSTALL_BASE /usr CACHE STRING "zfs installation base directory")
+set(CMAKE_INSTALL_PREFIX /usr/local)
 set(CMAKE_C_STANDARD 11)
 
-include_directories(${INSTALL_DIR}/include/libspl ${INSTALL_DIR}/include/libzfs)
-link_directories(${INSTALL_DIR}/lib)
+include_directories(${ZFS_INSTALL_BASE}/include/libspl ${ZFS_INSTALL_BASE}/include/libzfs)
+link_directories(${ZFS_INSTALL_BASE}/lib)
 add_executable(zpool_prometheus
         zpool_prometheus.c)
 target_link_libraries(zpool_prometheus zfs nvpair)
-install(TARGETS zpool_prometheus DESTINATION ${INSTALL_DIR}/bin)
+install(TARGETS zpool_prometheus DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
 set(CPACK_GENERATOR "DEB")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS "ON")

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ It is as simple as possible, but no simpler.
 By default, [ZFSonLinux](https://github.com/zfsonlinux/zfs) 
 installs the necessary header and library files in _/usr/local_.
 If you place those files elsewhere, then edit _CMakeLists.txt_ and
-change the _INSTALL_DIR_
+change the _CMAKE_INSTALL_PREFIX_
 ```bash
 # generic ZFSonLinux build
 cmake .
@@ -159,7 +159,7 @@ There are two basic methods known to work:
 
 Helpful comments in the source code are available.
 
-To install the _zpool_prometheus_ executable in _INSTALL_DIR_, use
+To install the _zpool_prometheus_ executable in _CMAKE_INSTALL_PREFIX_, use
 ```bash
 make install
 ```


### PR DESCRIPTION
I was confused when different CMakeLists variants used totally different conventions/variables. Both build configs should only differ in the platform specific parts (e.g. different search paths or packaging options).

This PR
* uses `ZFS_INSTALL_BASE` consistently for the OpenZFS location now
* decouples the location of OpenZFS from the installation target
* uses the standard `CMAKE_INSTALL_PREFIX` for the installation target
* requires #10 to also make the build options the same